### PR TITLE
chore: Add permissions to GitHub workflows

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -1,5 +1,9 @@
 name: 'Build Artifact'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,4 +1,7 @@
 name: Continuous Integration
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: 'Release'
 
+permissions:
+    contents: read
+    pull-requests: write
+
 on: [ workflow_dispatch ]
 
 env:


### PR DESCRIPTION
- This change ensures GitHub workflows have necessary permissions.
- It addresses potential permission errors preventing workflows from accessing files and pull requests.
- The `permissions` section was added to the `continuous-integration.yaml`, `build-artifact.yaml`, and `release.yml` workflow files.