### PR TITLE
feat: Enhance export functionality for KR52 reports

### DIFF
--- a/src/main/java/org/cynic/ltg_export/Configuration.java
+++ b/src/main/java/org/cynic/ltg_export/Configuration.java
@@ -2,6 +2,24 @@ package org.cynic.ltg_export;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.xml.ws.BindingProvider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
@@ -33,140 +51,121 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
-import javax.script.Bindings;
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Clock;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
 @SpringBootConfiguration(proxyBeanMethods = false)
 @ImportAutoConfiguration({
-  //        Configuration properties
-  ConfigurationPropertiesAutoConfiguration.class,
+    //        Configuration properties
+    ConfigurationPropertiesAutoConfiguration.class,
 
-  //    Jackson configuration
-  JacksonAutoConfiguration.class,
+    //    Jackson configuration
+    JacksonAutoConfiguration.class,
 
-  //    Message source
-  MessageSourceAutoConfiguration.class
+    //    Message source
+    MessageSourceAutoConfiguration.class
 
 })
 @ComponentScan(excludeFilters = {@ComponentScan.Filter(type = FilterType.CUSTOM, classes = {TypeExcludeFilter.class}),
-  @ComponentScan.Filter(type = FilterType.CUSTOM, classes = {AutoConfigurationExcludeFilter.class})})
+    @ComponentScan.Filter(type = FilterType.CUSTOM, classes = {AutoConfigurationExcludeFilter.class})})
 @EnableConfigurationProperties({Configuration.ExportConfiguration.class})
 public class Configuration {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
-  public Configuration() {
-    Optional.of(LOGGER).filter(it -> it.isInfoEnabled(Constants.AUDIT_MARKER)).map(it -> getClass()).map(Class::getPackage)
-      .ifPresent(it -> LOGGER.info(Constants.AUDIT_MARKER, "[{}-{}] STARTED", it.getImplementationTitle(), it.getImplementationVersion()));
-  }
-
-  @Bean
-  public Clock clock() {
-    return Clock.system(Constants.SYSTEM_ZONE_ID);
-  }
-
-  @Bean
-  public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
-    return builder.createXmlMapper(true).build();
-  }
-
-  @Bean
-  public WaybillsImportServiceSoap waybillsImportServiceSoap(@Value("${webservice.ltg.waybills-import.endpoint}") String endpoint) {
-    WaybillsImportService waybillsImportService = new WaybillsImportService();
-    WaybillsImportServiceSoap waybillsImportServiceSoap = waybillsImportService.getWaybillsImportServiceSoap();
-    BindingProvider.class.cast(waybillsImportServiceSoap).getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpoint);
-
-    return waybillsImportServiceSoap;
-  }
-
-  @Bean
-  public BiConsumer<String, byte[]> writer() {
-    return (fileName, data) -> {
-
-      try {
-        Files.write(Path.of(fileName), data);
-      } catch (IOException e) {
-        throw new ApplicationException("error.writer.io", Map.entry("fileName", fileName), Map.entry("size", ArrayUtils.getLength(data)),
-          Map.entry("message", ExceptionUtils.getRootCauseMessage(e)));
-      }
-    };
-  }
-
-  @Bean
-  public Function<OutputStream, CSVPrinter> csvPrinter() {
-    return outputStream -> {
-      try {
-        return new CSVPrinter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8),
-          CSVFormat.Builder.create(CSVFormat.EXCEL)
-            .setQuoteMode(QuoteMode.ALL)
-            .build());
-      } catch (IOException e) {
-        throw new ApplicationException(
-          "error.csv-printer",
-          Map.entry("message", ExceptionUtils.getRootCauseMessage(e))
-        );
-      }
-    };
-  }
-
-
-  @Bean
-  public BiFunction<String, String, String> expression(MessageSource messageSource) {
-    ScriptEngineManager manager = new ScriptEngineManager();
-
-    return (expression, item) -> {
-      ScriptEngine engine = manager.getEngineByName("groovy");
-      Bindings bindings = engine.createBindings();
-      bindings.put("value", item);
-      bindings.put("station", (Function<String, String>) value -> messageSource.getMessage(value, null, Constants.LOCALE));
-
-      String script = Constants.Template.EXPRESSION.template(
-        ClassUtils.getCanonicalName(StringUtils.class),
-        ClassUtils.getCanonicalName(RegExUtils.class),
-        expression
-      );
-
-      engine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
-
-      return Optional.of(engine)
-        .map(ThrowingFunction.withTry(
-          it -> it.eval(script),
-          () -> StringUtils.EMPTY
-        ))
-        .map(Object::toString)
-        .orElse(StringUtils.EMPTY);
-
-    };
-  }
-
-  @ConfigurationProperties(prefix = "export")
-  public static class ExportConfiguration extends HashSet<ReportExportConfiguration> {
-
-    public record ReportExportConfiguration(String name, Type type, Set<FieldReportExportConfiguration> fields) {
-
-      public enum Type {
-        KR99, KR52
-      }
-
-      public record FieldReportExportConfiguration(Integer index, String label, String path, String filter, String transform) {
-
-      }
+    public Configuration() {
+        Optional.of(LOGGER).filter(it -> it.isInfoEnabled(Constants.AUDIT_MARKER)).map(it -> getClass()).map(Class::getPackage)
+            .ifPresent(it -> LOGGER.info(Constants.AUDIT_MARKER, "[{}-{}] STARTED", it.getImplementationTitle(), it.getImplementationVersion()));
     }
-  }
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(Constants.SYSTEM_ZONE_ID);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
+        return builder.createXmlMapper(true).build();
+    }
+
+    @Bean
+    public WaybillsImportServiceSoap waybillsImportServiceSoap(@Value("${webservice.ltg.waybills-import.endpoint}") String endpoint) {
+        WaybillsImportService waybillsImportService = new WaybillsImportService();
+        WaybillsImportServiceSoap waybillsImportServiceSoap = waybillsImportService.getWaybillsImportServiceSoap();
+        BindingProvider.class.cast(waybillsImportServiceSoap).getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpoint);
+
+        return waybillsImportServiceSoap;
+    }
+
+    @Bean
+    public BiConsumer<String, byte[]> writer() {
+        return (fileName, data) -> {
+
+            try {
+                Files.write(Path.of(fileName), data);
+            } catch (IOException e) {
+                throw new ApplicationException("error.writer.io", Map.entry("fileName", fileName), Map.entry("size", ArrayUtils.getLength(data)),
+                    Map.entry("message", ExceptionUtils.getRootCauseMessage(e)));
+            }
+        };
+    }
+
+    @Bean
+    public Function<OutputStream, CSVPrinter> csvPrinter() {
+        return outputStream -> {
+            try {
+                return new CSVPrinter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8),
+                    CSVFormat.Builder.create(CSVFormat.EXCEL)
+                        .setQuoteMode(QuoteMode.ALL)
+                        .build());
+            } catch (IOException e) {
+                throw new ApplicationException(
+                    "error.csv-printer",
+                    Map.entry("message", ExceptionUtils.getRootCauseMessage(e))
+                );
+            }
+        };
+    }
+
+
+    @Bean
+    public BiFunction<String, String, String> expression(MessageSource messageSource) {
+        ScriptEngineManager manager = new ScriptEngineManager();
+
+        return (expression, item) -> {
+            ScriptEngine engine = manager.getEngineByName("groovy");
+            Bindings bindings = engine.createBindings();
+            bindings.put("value", item);
+            bindings.put("station", (Function<String, String>) value -> messageSource.getMessage(value, null, Constants.LOCALE));
+
+            String script = Constants.Template.EXPRESSION.template(
+                ClassUtils.getCanonicalName(StringUtils.class),
+                ClassUtils.getCanonicalName(RegExUtils.class),
+                expression
+            );
+
+            engine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
+
+            return Optional.of(engine)
+                .map(ThrowingFunction.withTry(
+                    it -> it.eval(script),
+                    () -> StringUtils.EMPTY
+                ))
+                .map(Object::toString)
+                .orElse(StringUtils.EMPTY);
+
+        };
+    }
+
+    @ConfigurationProperties(prefix = "export")
+    public static class ExportConfiguration extends HashSet<ReportExportConfiguration> {
+
+        public record ReportExportConfiguration(String name, Type type, Set<FieldReportExportConfiguration> fields) {
+
+            public enum Type {
+                KR99, KR52
+            }
+
+            public record FieldReportExportConfiguration(Integer index, String label, String path, String filter, String transform) {
+
+            }
+        }
+    }
 }

--- a/src/main/java/org/cynic/ltg_export/service/ExportService.java
+++ b/src/main/java/org/cynic/ltg_export/service/ExportService.java
@@ -2,8 +2,19 @@ package org.cynic.ltg_export.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.jayway.jsonpath.JsonPath;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import net.minidev.json.JSONArray;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ClassUtils;
@@ -17,142 +28,109 @@ import org.cynic.ltg_export.function.ThrowingConsumer;
 import org.cynic.ltg_export.function.ThrowingFunction;
 import org.springframework.stereotype.Component;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
 @Component
 public class ExportService {
 
-  private final Function<OutputStream, CSVPrinter> csvPrinter;
-  BiFunction<String, String, String> expression;
-  private final Set<Configuration.ExportConfiguration.ReportExportConfiguration> configurations;
+    private final Function<OutputStream, CSVPrinter> csvPrinter;
+    BiFunction<String, String, String> expression;
+    private final Set<Configuration.ExportConfiguration.ReportExportConfiguration> configurations;
 
-  public ExportService(
-    Function<OutputStream, CSVPrinter> csvPrinter,
-    BiFunction<String, String, String> expression,
-    Set<Configuration.ExportConfiguration.ReportExportConfiguration> configurations) {
+    public ExportService(
+        Function<OutputStream, CSVPrinter> csvPrinter,
+        BiFunction<String, String, String> expression,
+        Set<Configuration.ExportConfiguration.ReportExportConfiguration> configurations) {
 
-    this.csvPrinter = csvPrinter;
-    this.expression = expression;
-    this.configurations = configurations;
-  }
-
-  public Supplier<byte[]> export(
-    String name, List<JsonNode> items) {
-    ReportExportConfiguration configuration =
-      configurations.stream()
-        .filter(it -> StringUtils.equals(it.name(), name))
-        .findAny()
-        .orElseThrow(
-          () -> new ApplicationException("error.export.not-supported", Map.entry("name", name))
-        );
-
-    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-         CSVPrinter printer = csvPrinter.apply(outputStream)) {
-      printer.printRecord(header(configuration));
-
-      items.parallelStream().map(it -> line(it, configuration))
-        .flatMap(Collection::stream)
-        .forEach(ThrowingConsumer.withTry(
-          printer::printRecord,
-          e -> new ApplicationException("error.export.print",
-            Map.entry("message", ExceptionUtils.getRootCauseMessage(e))
-          )
-        ));
-
-      return outputStream::toByteArray;
-    } catch (IOException e) {
-      throw new ApplicationException("error.export",
-        Map.entry("message", ExceptionUtils.getRootCauseMessage(e))
-      );
+        this.csvPrinter = csvPrinter;
+        this.expression = expression;
+        this.configurations = configurations;
     }
-  }
 
-  private List<List<String>> line(JsonNode item, ReportExportConfiguration configuration) {
-    return cartesian(
-      configuration.fields()
-        .stream()
-        .sorted(Comparator.comparingInt(FieldReportExportConfiguration::index))
-        .map(it -> parse(item, it))
-        .toList()
-    );
-  }
+    public Supplier<byte[]> export(
+        String name, List<JsonNode> items) {
+        ReportExportConfiguration configuration =
+            configurations.stream()
+                .filter(it -> StringUtils.equals(it.name(), name))
+                .findAny()
+                .orElseThrow(
+                    () -> new ApplicationException("error.export.not-supported", Map.entry("name", name))
+                );
 
-  private static List<String> header(ReportExportConfiguration configuration) {
-    return configuration.fields()
-      .stream()
-      .sorted(Comparator.comparingInt(FieldReportExportConfiguration::index))
-      .map(FieldReportExportConfiguration::label)
-      .toList();
-  }
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            CSVPrinter printer = csvPrinter.apply(outputStream)) {
+            printer.printRecord(header(configuration));
 
-  private static List<List<String>> cartesian(List<List<String>> data) {
-    return data.stream()
-      .map(it -> it.stream().map(Arrays::asList).toList())
-      .reduce((item, other) -> item.stream()
-        .flatMap(value -> other.stream().map(otherValue -> {
-          List<String> merged = new ArrayList<>(value);
-          merged.addAll(otherValue);
-          return merged;
-        }))
-        .toList())
-      .orElse(List.of())
-      .stream()
-      .distinct()
-      .toList();
-  }
+            items.parallelStream().map(it -> line(it, configuration))
+                .forEach(ThrowingConsumer.withTry(
+                    printer::printRecord,
+                    e -> new ApplicationException("error.export.print",
+                        Map.entry("message", ExceptionUtils.getRootCauseMessage(e))
+                    )
+                ));
 
-  private List<String> parse(JsonNode item, FieldReportExportConfiguration field) {
-    return Optional.of(item)
-      .map(JsonNode::toString)
-      .map(ThrowingFunction.withTry(
-        it -> JsonPath.<Object>read(it, field.path()),
-        () -> StringUtils.EMPTY
-      ))
-      .map(result -> Optional.of(result)
-        .filter(it -> ClassUtils.isAssignable(it.getClass(), JSONArray.class))
-        .map(it -> JSONArray.class.cast(it)
-          .stream()
-          .toList()
-        )
-        .orElse(List.of(result))
-        .stream()
-        .map(Object::toString)
-        .map(it -> mutate(field, it))
-        .toList()
-      )
-      .filter(CollectionUtils::isNotEmpty)
-      .orElse(List.of(StringUtils.EMPTY));
-  }
+            return outputStream::toByteArray;
+        } catch (IOException e) {
+            throw new ApplicationException("error.export",
+                Map.entry("message", ExceptionUtils.getRootCauseMessage(e))
+            );
+        }
+    }
 
-  private String mutate(FieldReportExportConfiguration field, String value) {
-    Boolean filter = Optional.of(field)
-      .map(FieldReportExportConfiguration::filter)
-      .map(StringUtils::trimToNull)
-      .map(it -> expression.apply(it, value))
-      .map(BooleanUtils::toBoolean)
-      .orElse(Boolean.TRUE);
+    private List<String> line(JsonNode item, ReportExportConfiguration configuration) {
+        return configuration.fields()
+            .stream()
+            .sorted(Comparator.comparingInt(FieldReportExportConfiguration::index))
+            .map(it -> parse(item, it))
+            .toList();
+    }
 
-    return Optional.of(filter)
-      .filter(Boolean.TRUE::equals)
-      .map(it -> Optional.of(field)
-        .map(FieldReportExportConfiguration::transform)
-        .map(StringUtils::trimToNull)
-        .map(t -> expression.apply(t, value))
-        .map(Object::toString)
-        .orElse(value)
-      ).orElse(StringUtils.EMPTY);
-  }
+    private static List<String> header(ReportExportConfiguration configuration) {
+        return configuration.fields()
+            .stream()
+            .sorted(Comparator.comparingInt(FieldReportExportConfiguration::index))
+            .map(FieldReportExportConfiguration::label)
+            .toList();
+    }
+
+    private String parse(JsonNode item, FieldReportExportConfiguration field) {
+        return Optional.of(item)
+            .map(JsonNode::toString)
+            .map(ThrowingFunction.withTry(
+                it -> JsonPath.<Object>read(it, field.path()),
+                () -> StringUtils.EMPTY
+            ))
+            .map(result -> Optional.of(result)
+                .filter(it -> ClassUtils.isAssignable(it.getClass(), JSONArray.class))
+                .map(it -> JSONArray.class.cast(it)
+                    .stream()
+                    .map(Object::toString)
+                    .collect(Collectors.joining("; "))
+                )
+                .orElseGet(() -> Optional.of(result)
+                    .map(Object::toString)
+                    .orElse(StringUtils.EMPTY)
+                )
+            )
+            .map(Object::toString)
+            .map(it -> mutate(field, it))
+            .orElse(StringUtils.EMPTY);
+    }
+
+    private String mutate(FieldReportExportConfiguration field, String value) {
+        Boolean filter = Optional.of(field)
+            .map(FieldReportExportConfiguration::filter)
+            .map(StringUtils::trimToNull)
+            .map(it -> expression.apply(it, value))
+            .map(BooleanUtils::toBoolean)
+            .orElse(Boolean.TRUE);
+
+        return Optional.of(filter)
+            .filter(Boolean.TRUE::equals)
+            .map(it -> Optional.of(field)
+                .map(FieldReportExportConfiguration::transform)
+                .map(StringUtils::trimToNull)
+                .map(t -> expression.apply(t, value))
+                .map(Object::toString)
+                .orElse(value)
+            ).orElse(StringUtils.EMPTY);
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -164,3 +164,21 @@ export:
         path: $.KR52Vaztarastis.NeGelZymos
         filter: StringUtils.containsIgnoreCase(value, "БАЛТИК КАРГО АГЕНТ")
         transform: RegExUtils.dotAllMatcher("БАЛТИК\\s+КАРГО\\s+АГЕНТ.*ПОДКОД\s*-?\s*\\d+\\s*/\\s*(\\d+)", value).results().findFirst().map({ it.group(1) }).orElse("")
+      - index: 29
+        label: Tarifų knygos pavadinimas
+        path: $.KR52Vaztarastis.KR52Mokesciai.TarifuKnygosPav
+      - index: 30
+        label: Vežimo tarifas
+        path: $.KR52Vaztarastis.KR52Mokesciai.VezimoTarifas
+      - index: 31
+        label: Vežimo tarifo valiuta
+        path: $.KR52Vaztarastis.KR52Mokesciai.VezimoTarifoValiuta
+      - index: 32
+        label: Suma (be PVM)
+        path: $.KR52Vaztarastis.KR52Mokesciai.SumaBePVMValiuta
+      - index: 33
+        label: Suma (ue PVM)
+        path: $.KR52Vaztarastis.KR52Mokesciai.SumaSuPVMValiuta
+      - index: 34
+        label: Mokesčio šalis
+        path: $.KR52Vaztarastis.KR52Mokesciai.Salis


### PR DESCRIPTION
- Adds support for new fields in KR52 report exports, including tariff book name, transportation tariff, currency, amounts (with and without VAT), and tax country.
- Extends the application.yaml configuration to define these new fields and their mappings.
- Modifies the Configuration.java, ExportService.java classes to handle the new fields and their associated logic.