### PR TITLE
fix: Update labels in application.yaml

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,14 +59,17 @@ export:
         label: Išduotas
         path: $.KR99Vaztarastis.IsdavimoLaikas
       - index: 11
-        label: Suma (bendra su PVM)
-        path: $.KR99Vaztarastis.KR99Mokesciai[*].SumaSuPVMValiuta
-      - index: 12
         label: Suma (su PVM)
         path: $.KR99Vaztarastis.KR99Mokesciai[*].SumaSuPVMValiuta
+      - index: 12
+        label: Suma (be PVM)
+        path: $.KR99Vaztarastis.KR99Mokesciai[*].SumaBePVMValiuta
       - index: 13
         label: Valiuta
         path: $.KR99Vaztarastis.KR99Mokesciai[*].VezimoTarifoValiuta
+      - index: 14
+        label: Tarifų knygos pavadinimas
+        path: $.KR99Vaztarastis.KR99Mokesciai[*].TarifuKnygosPav
   - name: KR52_Default
     type: KR52
     fields:


### PR DESCRIPTION
- The labels for sum and currency in the application.yaml file were incorrect.
- This commit corrects the labels to accurately reflect the sum with and without VAT, as well as adding a label for tariff book name.
- The change was introduced in the `src/main/resources/application.yaml` file.